### PR TITLE
caam_keyblob: Fix the caam_jr_enqueue() return value check

### DIFF
--- a/caam_keyblob.c
+++ b/caam_keyblob.c
@@ -412,7 +412,8 @@ static int gen_mem_encap(struct device *jr_dev, void __user *secretbuf,
 
 	retval = caam_jr_enqueue(jr_dev, encapdesc, sm_key_job_done,
 			&testres);
-	if (!retval) {
+	if (retval == 0 || retval == -EINPROGRESS) {
+		retval = 0;
 		wait_for_completion_interruptible(&testres.completion);
 
 		if (testres.error) {
@@ -512,7 +513,8 @@ static int gen_mem_decap(struct device *jr_dev, void __user *keyblobbuf,
 
 	retval = caam_jr_enqueue(jr_dev, decapdesc, sm_key_job_done,
 			&testres);
-	if (!retval) {
+	if (retval == 0 || retval == -EINPROGRESS) {
+		retval = 0;
 		wait_for_completion_interruptible(&testres.completion);
 
 		if (testres.error) {


### PR DESCRIPTION
Since commit 4d370a103695 ("crypto: caam - change return code
in caam_jr_enqueue function") the caam_jr_enqueue() does not return 0
on success anymore.

The new return value when caam_jr_enqueue() succeeds is
-EINPROGRESS.

Check for both the old and the new return values so that
caam_keyblob can work with old and new kernels.

Tested on a imx7s-warp board running 5.10.76.

A big thanks to Jó Ágila Bitsch for pointing out the caam_jr_enqueue()
return value change.

Signed-off-by: Fabio Estevam <festevam@denx.de>